### PR TITLE
Add URL query tracking for StateMachine

### DIFF
--- a/src/StateButton.tsx
+++ b/src/StateButton.tsx
@@ -1,0 +1,15 @@
+import { ButtonHTMLAttributes } from 'react'
+import { useStateMachine } from './StateMachine'
+
+interface StateButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  to: string
+}
+
+export default function StateButton({ to, children, ...rest }: StateButtonProps) {
+  const { gotoState } = useStateMachine()
+  return (
+    <button {...rest} onClick={() => gotoState(to)}>
+      {children ?? to}
+    </button>
+  )
+}

--- a/src/com/Controls.tsx
+++ b/src/com/Controls.tsx
@@ -1,13 +1,9 @@
-import {useStateMachine} from '@/StateMachine'
-
+import StateButton from '@/StateButton'
 
 export default function Controls() {
-    const {gotoState} = useStateMachine()
-
-
     return <div>
-        <button onClick={()=>gotoState('one')}>One</button>
-        <button onClick={()=>gotoState('two')}>Two</button>
-        <button onClick={()=>gotoState('three')}>Three</button>
+        <StateButton to='one'>One</StateButton>
+        <StateButton to='two'>Two</StateButton>
+        <StateButton to='three'>Three</StateButton>
     </div>
 }


### PR DESCRIPTION
## Summary
- track current state via hash query param `yg-<name>`
- sync state from URL changes and expose a `StateButton` helper
- update Controls to use `StateButton`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68489bda6700832792fe1d646111daab