### PR TITLE
Add availableTransitions to context

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ shared with a specific step active.
 - `State` component for declaring individual states with optional `onEnter`,
   `onExit` and `transition` props.
 - `useStateMachine` hook for reading or changing the current state.
+- `availableTransitions` property on the context for listing allowed
+  transitions from the active state.
 - `StateButton` convenience component for state navigation.
 - URL hash integration so state can be persisted across refreshes.
 
@@ -50,15 +52,22 @@ function Example() {
 }
 ```
 
-Within any state you can call `useStateMachine()` to programmatically navigate or
-to check the current state.
+Within any state you can call `useStateMachine()` to programmatically navigate,
+inspect the current state or check which transitions are allowed.
 
 ```tsx
 import { useStateMachine } from 'ygdrassil'
 
 function NextButton() {
-  const { gotoState } = useStateMachine()
-  return <button onClick={() => gotoState('next')}>Next</button>
+  const { gotoState, availableTransitions } = useStateMachine()
+  return (
+    <button
+      disabled={!availableTransitions.includes('next')}
+      onClick={() => gotoState('next')}
+    >
+      Next
+    </button>
+  )
 }
 ```
 

--- a/src/StateMachine.tsx
+++ b/src/StateMachine.tsx
@@ -24,6 +24,7 @@ interface Ctx {
   currentState: string
   gotoState: (name: string) => void
   is: (name: string) => boolean
+  availableTransitions: string[]
   query: URLSearchParams
   setQuery: (obj: Record<string, string>, replace?: boolean) => void
 }
@@ -167,6 +168,7 @@ export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, n
       currentState,
       gotoState,
       is: (s: string) => s === currentState,
+      availableTransitions: statesRef.current[currentState]?.transition ?? [],
       query,
       setQuery,
     }),

--- a/src/com/First/Controls.tsx
+++ b/src/com/First/Controls.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react'
+import { useEffect } from 'react'
 import {StateButton} from '@/StateMachine'
 import {useStateMachine} from '@/StateMachine'
 

--- a/src/com/First/One.tsx
+++ b/src/com/First/One.tsx
@@ -5,11 +5,11 @@ import {useStateMachine} from '@/StateMachine'
 export default function One() {
     const {query, setQuery} = useStateMachine()
 
-    const [count, setCount] = useState(query.one || 0)
+    const [count, setCount] = useState(Number(query.get('one')) || 0)
     
     useEffect(() => {
-        setQuery({one: +count})
-    }, [count])
+        setQuery({one: String(count)})
+    }, [count, setQuery])
 
     
     return <div>


### PR DESCRIPTION
## Summary
- expose availableTransitions from StateMachine context
- document availableTransitions in README with usage example
- clean up demo code so lint/build pass

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68497dca938c8327a31a2fb1a0727c4f