### PR TITLE
Make query object

### DIFF
--- a/src/com/First/One.tsx
+++ b/src/com/First/One.tsx
@@ -5,7 +5,7 @@ import {useStateMachine} from '@/StateMachine'
 export default function One() {
     const {query, setQuery} = useStateMachine()
 
-    const [count, setCount] = useState(Number(query.get('one')) || 0)
+    const [count, setCount] = useState(Number(query['one']) || 0)
     
     useEffect(() => {
         setQuery({one: String(count)})


### PR DESCRIPTION
## Summary
- store query string params in an object instead of URLSearchParams
- adjust the demo to use the new object interface

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68498546db888327a0d4cadb9c998ee3