### PR TITLE
Ensure state machines listen for hash changes without initial state

### DIFF
--- a/src/StateMachine.tsx
+++ b/src/StateMachine.tsx
@@ -115,6 +115,10 @@ export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, n
   const [currentState, setCurrentState] = useState<string | undefined>(
     () => readParam() ?? initial,
   )
+  const currentRef = useRef<string | undefined>(currentState)
+  useEffect(() => {
+    currentRef.current = currentState
+  }, [currentState])
   const [query, setQueryState] = useState<Record<string, string | number>>(() => readQuery())
 
   /** Registry of all states declared as children */
@@ -191,7 +195,7 @@ export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, n
     const handler = () => {
       const next = readParam()
       if (next) {
-        if (next !== currentState) gotoState(next)
+        if (next !== currentRef.current) gotoState(next)
       } else {
         setCurrentState(undefined)
       }
@@ -200,7 +204,7 @@ export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, n
     handler()
     window.addEventListener('hashchange', handler)
     return () => window.removeEventListener('hashchange', handler)
-  }, [currentState, gotoState, readParam, readQuery])
+  }, [gotoState, readParam, readQuery])
 
 
   /* ---------- 3. Context value ---------- */


### PR DESCRIPTION
## Summary
- update hash listener to use a ref
- keep listener active even when there is no initial state

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849e38a67648327ade10f05a81354b1