### PR TITLE
Support removal of query parameters via setQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ function Counter() {
 Pass `true` as the second argument to `setQuery` to replace existing values
 instead of merging them.
 
+To remove a query parameter pass `null` as its value (using `undefined` also
+works). When `replace` is `false` only the provided keys are deleted from the
+current query string.
+
 ## Development
 
 This repository includes a small demo app. After installing dependencies run:

--- a/src/StateMachine.tsx
+++ b/src/StateMachine.tsx
@@ -31,7 +31,10 @@ interface Ctx extends StateRegistrationCtx {
   is: (name: string) => boolean
   availableTransitions: string[]
   query: Record<string, string | number>
-  setQuery: (obj: Record<string, string | number>, replace?: boolean) => void
+  setQuery: (
+    obj: Record<string, string | number | null | undefined>,
+    replace?: boolean,
+  ) => void
 }
 
 export const StateMachineContext = createContext<Ctx | undefined>(undefined)
@@ -187,7 +190,10 @@ export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, n
   }, [machineStateParam])
 
   const setQuery = useCallback(
-    (obj: Record<string, string | number>, replace = false) => {
+    (
+      obj: Record<string, string | number | null | undefined>,
+      replace = false,
+    ) => {
       setQueryState(prev => {
         const base = replace
           ? Object.fromEntries(
@@ -195,8 +201,11 @@ export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, n
             )
           : { ...prev }
 
-        for (const [k, v] of Object.entries(obj)) base[k] = v
-        
+        for (const [k, v] of Object.entries(obj)) {
+          if (v == null) delete base[k]
+          else base[k] = v
+        }
+
         // Convert to strings for URL
         const urlParams = Object.fromEntries(
           Object.entries(base).map(([k, v]) => [k, String(v)])


### PR DESCRIPTION
## Summary
- allow `setQuery` to accept `null`/`undefined`
- remove keys when `setQuery` receives nullish values
- document how to remove query parameters

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684acb9ca184832785cec7c3fb6306d7