### PR TITLE
Add target option to link components

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ shared with a specific step active.
   transitions from the active state.
 - `StateButton` convenience component for state navigation (supports linking
   to another machine via the `machine` prop).
-- `StateLink` and `ExternalLink` components for anchor-based navigation.
+- `StateLink` and `ExternalLink` components for anchor-based navigation (support a `target` prop).
 - `query` and `setQuery` helpers for persisting extra values in the hash.
 - URL hash integration so state can be persisted across refreshes.
 
@@ -66,6 +66,7 @@ Prefer `<StateLink>`/`<ExternalLink>` when you need a traditional anchor:
 ```tsx
 <StateLink to="two">Go to step two</StateLink>
 ```
+You can pass `target` to either link component; blank values are ignored so `target="_blank"` works as expected.
 
 Within any state you can call `useStateMachine()` to programmatically navigate,
 inspect the current state, read query values or check which transitions are

--- a/src/StateMachine.tsx
+++ b/src/StateMachine.tsx
@@ -326,9 +326,11 @@ interface StateLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string
   data?: Record<string, string | number>
   replace?: boolean
+  /** Optional target for the underlying anchor. Blank values are ignored */
+  target?: string
 }
 
-export function StateLink({ data, replace, to, children, className, ...rest }: StateLinkProps) {
+export function StateLink({ data, replace, to, target, children, className, ...rest }: StateLinkProps) {
   const { is, query, param } = useStateMachine()
 
   const classNames = [className, is(to) ? 'active' : undefined]
@@ -354,16 +356,27 @@ export function StateLink({ data, replace, to, children, className, ...rest }: S
     return `#?${new URLSearchParams(urlParams).toString()}`
   }, [to, data, replace, query, param])
 
-  return <a {...rest} className={classNames} href={href}>{children ?? to}</a>
+  return (
+    <a
+      {...rest}
+      {...(target ? { target } : {})}
+      className={classNames}
+      href={href}
+    >
+      {children ?? to}
+    </a>
+  )
 }
 
 interface ExternalLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string
   machine: string
   data?: Record<string, string | number>
+  /** Optional target for the underlying anchor. Blank values are ignored */
+  target?: string
 }
 
-export function ExternalLink({ data, machine, to, children, className, ...rest }: ExternalLinkProps) {
+export function ExternalLink({ data, machine, to, target, children, className, ...rest }: ExternalLinkProps) {
   const href = useMemo(() => {
     const currentHash = window.location.hash.startsWith('#?')
       ? window.location.hash.slice(2)
@@ -379,5 +392,14 @@ export function ExternalLink({ data, machine, to, children, className, ...rest }
     return `#?${params.toString()}`
   }, [to, data, machine])
 
-  return <a {...rest} className={className} href={href}>{children ?? to}</a>
+  return (
+    <a
+      {...rest}
+      {...(target ? { target } : {})}
+      className={className}
+      href={href}
+    >
+      {children ?? to}
+    </a>
+  )
 }


### PR DESCRIPTION
## Summary
- add optional `target` prop to `StateLink` and `ExternalLink`
- document link `target` usage in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d764e7de48327ad706fae5303bfbe