### PR TITLE
Support automatic URL updates for initial state

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ shared with a specific step active.
 - `StateLink` and `ExternalLink` components for anchor-based navigation (support a `target` prop).
 - `query` and `setQuery` helpers for persisting extra values in the hash.
 - URL hash integration so state can be persisted across refreshes.
+- Providing an `initial` state automatically updates the URL hash on load.
 
 ## Installation
 

--- a/src/StateMachine.tsx
+++ b/src/StateMachine.tsx
@@ -225,6 +225,21 @@ export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, n
     [],
   )
 
+  /* ---------- Push initial state to the URL on mount ---------- */
+  useEffect(() => {
+    if (!initial) return
+    const existing = readParam()
+    if (!existing) {
+      const currentHash = window.location.hash.startsWith('#?')
+        ? window.location.hash.slice(2)
+        : ''
+      const params = new URLSearchParams(currentHash)
+      params.set(machineStateParam, initial)
+      const newHash = `#?${params.toString()}`
+      window.history.replaceState(null, '', newHash)
+    }
+  }, [initial, readParam, machineStateParam])
+
   /* ---------- Watch for external hash changes ---------- */
   useEffect(() => {
     const handler = () => {


### PR DESCRIPTION
## Summary
- update README for initial routing info
- push initial state to the URL when a `StateMachine` mounts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857261727a48327ac3a554b0e0aea97