### PR TITLE
Allow null values for StateButton data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ shared with a specific step active.
 - `availableTransitions` property on the context for listing allowed
   transitions from the active state.
 - `StateButton` convenience component for state navigation (supports linking
-  to another machine via the `machine` prop).
+  to another machine via the `machine` prop). The `data` prop merges values
+  into the query string—pass `null` to remove a parameter.
 - `StateLink` and `ExternalLink` components for anchor-based navigation (support a `target` prop).
 - `query` and `setQuery` helpers for persisting extra values in the hash.
 - URL hash integration so state can be persisted across refreshes.

--- a/src/StateMachine.tsx
+++ b/src/StateMachine.tsx
@@ -292,7 +292,7 @@ export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, n
 
 interface StateButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   to: string
-  data?: Record<string, string | number>
+  data?: Record<string, string | number | null | undefined>
   replace?: boolean
 }
 


### PR DESCRIPTION
## Summary
- allow null/undefined values for `StateButton` `data` prop
- document how to remove query params via `StateButton`

## Testing
- `npm run build`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685aa8aa8d4483278cb5b4470672eaa8