### PR TITLE
Add className wrapper for StateMachine children

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ shared with a specific step active.
 - `query` and `setQuery` helpers for persisting extra values in the hash.
 - URL hash integration so state can be persisted across refreshes.
 - Providing an `initial` state automatically updates the URL hash on load.
+- Pass `className` to `StateMachine` to wrap its children in a div with those classes when active.
 
 ## Installation
 
@@ -34,7 +35,7 @@ import { StateMachine, State, StateButton } from 'ygdrassil'
 
 function Example() {
   return (
-    <StateMachine initial="one" name="demo">
+    <StateMachine initial="one" name="demo" className="wizard">
       <nav>
         <StateButton to="one">One</StateButton>
         <StateButton to="two">Two</StateButton>
@@ -56,6 +57,8 @@ function Example() {
   )
 }
 ```
+
+Passing `className` automatically wraps the machine's children in a `<div>` with those classes.
 
 Use the `machine` prop to link to a state in another machine on the page:
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,10 +14,9 @@ export default function App() {
 
     <ExternalButton className='badge' to='one' machine='app'>Start machine #1</ExternalButton>
 
-    <StateMachine name='app'>
-      <div className='state machine'>
-        <h1>First State-Machine</h1>
-        <ExternalButton className='badge' 
+    <StateMachine name='app' className='state machine'>
+      <h1>First State-Machine</h1>
+        <ExternalButton className='badge'
           to='alpha' machine='aux'
           data={{alpha: 0, beta: 'nada', gamma: 0, delta: 0}}
         >Start machine #2</ExternalButton>
@@ -34,13 +33,9 @@ export default function App() {
         <State name={M1.ST[2]}>
           <Three />
         </State>
-      </div>
     </StateMachine>
 
-    <div className='state machine'>
-      <StateMachine name='aux' initial='alpha'>
+    <StateMachine name='aux' initial='alpha' className='state machine'>
         <SecondMachine />
-      </StateMachine>
-    </div>
-  </>
-}
+    </StateMachine>
+  </>}

--- a/src/StateMachine.tsx
+++ b/src/StateMachine.tsx
@@ -87,13 +87,14 @@ export const State: React.FC<StateProps> = ({ name, onEnter, onExit, transition,
 interface StateMachineProps {
   initial?: string
   name?: string
+  className?: string
   children: ReactNode
 }
 
 /**
  * Top-level provider. Manages state registration and transitions.
  */
-export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, name }) => {
+export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, name, className }) => {
   const machineStateParam = `yg-${name ?? '#'}`
 
   const readParam = useCallback(() => {
@@ -285,7 +286,11 @@ export const StateMachine: React.FC<StateMachineProps> = ({ initial, children, n
   /* ---------- Render children normally ---------- */
   return (
     <StateMachineContext.Provider value={ctxValue}>
-      {currentState ? children : null}
+      {currentState
+        ? className
+          ? <div className={className}>{children}</div>
+          : children
+        : null}
     </StateMachineContext.Provider>
   )
 }


### PR DESCRIPTION
## Summary
- make `StateMachine` accept an optional `className` prop
- wrap machine children in a div when a class name is provided
- update demo `App` to use the new prop
- document `className` usage in README

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686e7b1a1cec83278e69261071e4093e